### PR TITLE
Fix: Allow IEC 104 Slave to start I-frame TX from 1 (NS=2)

### DIFF
--- a/iec104_class.cpp
+++ b/iec104_class.cpp
@@ -642,7 +642,7 @@ void iec104_class::parseAPDU(iec_apdu* papdu, int sz, bool accountandrespond) {
       VR_NEW = (papdu->NS & 0xFFFE);
 
       // if (VR_NEW != VR) {
-      if (VR_NEW != VR && VR_NEW != 2) { // allows for counting beginning with 1
+      if (VR_NEW != VR && VR_NEW != 2) { //  Allow initial I-frame from Slave with TX=1
         // sequence error, must close and reopen connection
         mLog.pushMsg("*** SEQUENCE ERROR! **************************");
         if (seq_order_check) {

--- a/iec104_class.cpp
+++ b/iec104_class.cpp
@@ -642,7 +642,7 @@ void iec104_class::parseAPDU(iec_apdu* papdu, int sz, bool accountandrespond) {
       VR_NEW = (papdu->NS & 0xFFFE);
 
       // if (VR_NEW != VR) {
-      if (VR_NEW != VR && VR_NEW != 1) { // allows for counting beginning with 1
+      if (VR_NEW != VR && VR_NEW != 2) { // allows for counting beginning with 1
         // sequence error, must close and reopen connection
         mLog.pushMsg("*** SEQUENCE ERROR! **************************");
         if (seq_order_check) {


### PR DESCRIPTION
Problem:

Some IEC 60870-5-104 Slave implementations, such as Honeywell 104 Slave, begin I-frame transmission with TX=1, which corresponds to NS=2 on the wire. However, the current master implementation contains the following logic:

if (VR_NEW != VR && VR_NEW != 1)

This condition is incorrect. According to the IEC 104 specification, the TX field is encoded in bit 1 (left-shifted by one). Therefore, when TX=1, NS=2, not 1. As a result, the master falsely reports a SEQUENCE ERROR on valid initial frames.

Fix:

This patch modifies the check to:

if (VR_NEW != VR && VR_NEW != 2)